### PR TITLE
fix: popup compatibility with preact

### DIFF
--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -131,7 +131,7 @@ const Popup: React.FC<PopupProps> = (props) => {
         }}
       >
         <div
-          style={{ ...style, display: !animatedVisible && 'none' }}
+          style={{ ...style, display: !visible && !animatedVisible ? 'none' : undefined }}
           className={classnames(
             bem({
               round,


### PR DESCRIPTION
Preact与React在对组件style以及useEffect与setState间的处理存在些许差异，导致Popup组件中的display无法被正确设置，通过些许调整可两边都兼容。望采纳！

BTW，我很喜欢你的这个库，尤其配合Preact做移动端App非常适合。