### PR TITLE
fix: stepper oninput and onblue conflict

### DIFF
--- a/src/stepper/index.tsx
+++ b/src/stepper/index.tsx
@@ -74,11 +74,10 @@ const Stepper: React.FC<StepperProps> = (props) => {
     [props.disabled, props.disableMinus, current],
   );
 
-  const plusDisabled = useMemo(() => props.disabled || props.disablePlus || current >= +props.max, [
-    props.disabled,
-    props.disablePlus,
-    current,
-  ]);
+  const plusDisabled = useMemo(
+    () => props.disabled || props.disablePlus || current >= +props.max,
+    [props.disabled, props.disablePlus, current],
+  );
 
   const inputStyle = useMemo(
     () => ({
@@ -142,10 +141,6 @@ const Stepper: React.FC<StepperProps> = (props) => {
     } else if (!equal(value, formatted)) {
       input.value = formatted;
     }
-
-    // perfer number type
-    const isNumeric = formatted === String(+formatted);
-    setValue(isNumeric ? +formatted : formatted);
   };
 
   const onFocus = (event: FormEvent) => {
@@ -161,6 +156,7 @@ const Stepper: React.FC<StepperProps> = (props) => {
     const input = event.target as HTMLInputElement;
     const value = format(input.value);
     input.value = String(value);
+    preValue.current = value;
     emit('change', value);
     emit('blur', event);
     resetScroll();


### PR DESCRIPTION
Stepper组件的onBlur会触发onChange，但是它又没有维护好preValue，导致在输入框有焦点时点击 + - 状态会不对。
另外Stepper在onInput里触发onChange会感觉太频繁了，没有必要，onBlur时触发就挺好。在我们的业务中每次onChange需要去调用一个API，如果太频繁了会影响功能与性能，当然我们也可以自己throttle，但始终还是觉得如果Stepper不那么频繁触发onChange会更好，因此这个PR里把onInput中的onChange触发去掉了。望采纳！