### PR TITLE
fix: set state in image events

### DIFF
--- a/src/image/index.tsx
+++ b/src/image/index.tsx
@@ -39,21 +39,30 @@ const Image: React.FC<ImageProps> = (props) => {
   }, []);
 
   useEffect(() => {
-    if (!mountedRef.current) {
-      mountedRef.current = true;
-      return;
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (mountedRef.current) {
+      setStatus({ error: false, loading: false });
     }
-    setStatus({ error: false, loading: false });
   }, [props.src]);
 
   const onLoad = (e) => {
-    setStatus((v) => ({ ...v, loading: false }));
-    props.onLoad?.(e);
+    if (mountedRef.current) {
+      setStatus((v) => ({ ...v, loading: false }));
+      props.onLoad?.(e);
+    }
   };
 
   const onError = (e) => {
-    setStatus({ error: true, loading: false });
-    props.onLoad?.(e);
+    if (mountedRef.current) {
+      setStatus({ error: true, loading: false });
+      props.onLoad?.(e);
+    }
   };
 
   const renderLoadingIcon = () => {


### PR DESCRIPTION
问题：
Image组件，图片正在加载的过程中组件被unmount，onLoad等事件回来后还是会set state，这会导致react报warning。现有代码中有mountedRef来跟踪组件的mounted情况，但是并没有被正确设置以及使用。

解决方法：
正确设置并使用mountedRef来避免问题。