### PR TITLE
fix: toast onClose may be called twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vant",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "React Mobile UI Components base on Vant UI",
   "repository": "https://github.com/3lang3/react-vant.git",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vant",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "React Mobile UI Components base on Vant UI",
   "repository": "https://github.com/3lang3/react-vant.git",
   "main": "lib/index.js",

--- a/src/toast/PropsType.ts
+++ b/src/toast/PropsType.ts
@@ -1,6 +1,6 @@
-import { BaseTypeProps } from '../utils';
-import { Position } from '../popup/PropsType';
 import { LoadingType } from '../loading/PropsType';
+import { Position } from '../popup/PropsType';
+import { BaseTypeProps } from '../utils';
 
 export interface ToastProps extends BaseTypeProps {
   icon?: string;
@@ -23,10 +23,10 @@ export interface ToastProps extends BaseTypeProps {
 
 type ToastInstanceOpts = Omit<ToastProps, 'type'> | string;
 export interface ToastInstance {
-  (opts: ToastProps | string): void;
-  info(opts: ToastInstanceOpts | string): void;
-  loading(opts: ToastInstanceOpts | string): void;
-  success(opts: ToastInstanceOpts | string): void;
-  fail(opts: ToastInstanceOpts | string): void;
+  (opts: ToastProps | string): React.Dispatch<React.SetStateAction<ToastProps>>;
+  info(opts: ToastInstanceOpts | string): React.Dispatch<React.SetStateAction<ToastProps>>;
+  loading(opts: ToastInstanceOpts | string): React.Dispatch<React.SetStateAction<ToastProps>>;
+  success(opts: ToastInstanceOpts | string): React.Dispatch<React.SetStateAction<ToastProps>>;
+  fail(opts: ToastInstanceOpts | string): React.Dispatch<React.SetStateAction<ToastProps>>;
   clear(): void;
 }

--- a/src/toast/index.tsx
+++ b/src/toast/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
-import { isObject } from '../utils';
+import { isObject, once } from '../utils';
 import { resolveContainer } from '../utils/dom/getContainer';
 import { lockClick } from './lock-click';
 import { ToastProps, ToastInstance } from './PropsType';
@@ -49,13 +49,16 @@ const Toast = (p: ToastProps): unknown => {
     const [visible, setVisible] = useState(true);
     const [state, setState] = useState<ToastProps>({ ...options });
     // clearDOM after animation
-    const internalAfterClose = () => {
-      onClose?.();
-      const unmountResult = ReactDOM.unmountComponentAtNode(container);
-      if (unmountResult && container.parentNode) {
-        container.parentNode.removeChild(container);
-      }
-    };
+    const internalAfterClose = useCallback(
+      once(() => {
+        onClose?.();
+        const unmountResult = ReactDOM.unmountComponentAtNode(container);
+        if (unmountResult && container.parentNode) {
+          container.parentNode.removeChild(container);
+        }
+      }),
+      [onClose, container],
+    );
 
     // close with animation
     const destroy = useCallback(() => {

--- a/src/utils/base.ts
+++ b/src/utils/base.ts
@@ -47,3 +47,11 @@ export function pick<T, U extends keyof T>(
     return ret;
   }, {} as Writeable<Pick<T, U>>);
 }
+
+export function once(fn: (...args: any) => void): (...args: any) => void {
+  return (...args: any) => {
+    if (!fn) return;
+    fn(...args);
+    fn = null;
+  };
+}


### PR DESCRIPTION
问题：
第二次调用Toast会发现它的onClose调用了两遍，问题在于在`useEffect`中将`internalAfterClose` push到了待下次显示时会调用的队列，但是BaseToast本身的onClose也会执行`internalAfterClose`。

解决方案：
首先保证internalAfterClose函数不会每次都变化，其次，通过保证其只执行一次可以回避在不同时机被两次调用的问题。
