### PR TITLE
fix: no loading if image src is a data url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vant",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "React Mobile UI Components base on Vant UI",
   "repository": "https://github.com/3lang3/react-vant.git",
   "main": "lib/index.js",

--- a/src/image/index.tsx
+++ b/src/image/index.tsx
@@ -47,7 +47,7 @@ const Image: React.FC<ImageProps> = (props) => {
 
   useEffect(() => {
     if (mountedRef.current) {
-      setStatus({ error: false, loading: !!props.src });
+      setStatus({ error: false, loading: !!props.src && !props.src.startsWith('data:image/') });
     }
   }, [props.src]);
 


### PR DESCRIPTION
问题：
如果给Image的是一个data url，那么它的onLoad会先于props.src的变化执行，导致loading设置出错。

解决方案：
对于data url不需要设置loading为true。