### PR TITLE
fix: image bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vant",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "React Mobile UI Components base on Vant UI",
   "repository": "https://github.com/3lang3/react-vant.git",
   "main": "lib/index.js",

--- a/src/image/index.tsx
+++ b/src/image/index.tsx
@@ -91,10 +91,18 @@ const Image: React.FC<ImageProps> = (props) => {
 
   const renderPlaceholder = () => {
     if (status.loading && showLoading) {
-      return <div className={classnames(bem('loading'))}>{renderLoadingIcon()}</div>;
+      return (
+        <div className={classnames(bem('loading'))} onClick={props.onClick}>
+          {renderLoadingIcon()}
+        </div>
+      );
     }
     if (status.error && showError) {
-      return <div className={classnames(bem('error'))}>{renderErrorIcon()}</div>;
+      return (
+        <div className={classnames(bem('error'))} onClick={props.onClick}>
+          {renderErrorIcon()}
+        </div>
+      );
     }
     return null;
   };

--- a/src/styles/themes/default.less
+++ b/src/styles/themes/default.less
@@ -449,7 +449,7 @@
 @image-preview-close-icon-color: @gray-5;
 @image-preview-close-icon-active-color: @gray-6;
 @image-preview-close-icon-margin: @padding-md;
-@image-preview-close-icon-z-index: 1;
+@image-preview-close-icon-z-index: 2;
 
 // List
 @list-icon-margin-right: 5 * @hd;


### PR DESCRIPTION
解决两个问题，一个是图片即使在显示占位图等状态下依然要接受和处理onClick；另一个是image preview中`@image-preview-close-icon-z-index`的不够高，导致实际close-icon点不到。