### PR TITLE
fix: ensure correct image onload calling order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vant",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "React Mobile UI Components base on Vant UI",
   "repository": "https://github.com/3lang3/react-vant.git",
   "main": "lib/index.js",

--- a/src/image/Image.tsx
+++ b/src/image/Image.tsx
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import { ImageProps } from './PropsType';
 import { isDef, addUnit, createNamespace } from '../utils';
 import Icon from '../icon';
-import { useUpdateEffect } from '../hooks';
 
 const [bem] = createNamespace('image');
 

--- a/src/image/Image.tsx
+++ b/src/image/Image.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useState, useRef, useMemo, useEffect } from 'react';
+import React, { CSSProperties, useState, useRef, useMemo, useEffect, useLayoutEffect } from 'react';
 import classnames from 'classnames';
 import { ImageProps } from './PropsType';
 import { isDef, addUnit, createNamespace } from '../utils';
@@ -37,7 +37,7 @@ const Image: React.FC<ImageProps> = (props) => {
     };
   }, []);
 
-  useUpdateEffect(() => {
+  useLayoutEffect(() => {
     setStatus({ error: false, loading: true });
   }, [props.src]);
 


### PR DESCRIPTION
图片有缓存的情况下`onLoad`会很快触发，有时会先于`src`变化的effect，用`useLayoutEffect`可以保证执行的顺序。