### PR TITLE
style(Popup): center the title

### DIFF
--- a/packages/react-vant/src/popup/style/index.less
+++ b/packages/react-vant/src/popup/style/index.less
@@ -136,6 +136,7 @@
     &__title {
       margin: 20 * @hd 50 * @hd 12 * @hd 20 * @hd;
       font-weight: 500;
+      text-align: center;
       font-size: @popup-title-font-size;
       line-height: @popup-title-font-size;
     }


### PR DESCRIPTION
`title`大部分情况下应该是居中的，可以自定义位置

![image](https://user-images.githubusercontent.com/33956589/133561133-dd58fa98-5f02-4e3d-b478-aae904052edd.png)

本次PR中ws 对less文件提示报错，没用过`stylelintrc`，定位不出报错原因🙈

![image](https://user-images.githubusercontent.com/33956589/133561252-19bdd017-624e-4af9-a923-fae85cd9c6aa.png)
