### PR TITLE
feat: add use-form-smart

### DIFF
--- a/packages/react-vant/src/hooks/use-form-smart.ts
+++ b/packages/react-vant/src/hooks/use-form-smart.ts
@@ -1,0 +1,65 @@
+import { Ref, useCallback, useEffect, useRef, useState } from 'react';
+import { isObject } from '../utils';
+
+function isEmpty(val: Record<string, unknown>) {
+  if (isObject(val)) {
+    return JSON.stringify(val) === '{}';
+  }
+  return true;
+}
+
+export type FormOption = {
+  /**
+   * initialValues
+   */
+  value?: Record<string, unknown>;
+  /**
+   * sync
+   */
+  sync?: boolean;
+};
+export type FormMethod = {
+  set: (values: unknown) => void;
+  get: (name: string) => unknown;
+  submit: () => void;
+  getAll: () => Record<string, unknown>;
+  clear: () => void;
+};
+export type FormState = [ref: Ref<unknown>, methods: FormMethod];
+
+export function useFormSmart(option: FormOption = {}): FormState {
+  const { value, sync } = option;
+  const ref = useRef(null);
+  const [once, setOnce] = useState<boolean>(false);
+  const set = useCallback((values: unknown) => {
+    ref?.current?.setFieldsValue(values);
+  }, []);
+  const get = useCallback((name: string) => {
+    return ref?.current?.getFieldValue(name);
+  }, []);
+
+  const submit = useCallback(() => {
+    ref?.current?.submit();
+  }, []);
+
+  const clear = useCallback(() => {
+    ref?.current?.resetFields();
+  }, []);
+
+  const getAll = useCallback(() => {
+    return ref?.current?.getFieldsValue();
+  }, []);
+
+  useEffect(() => {
+    if (!isEmpty(value)) {
+      if (sync) {
+        set(value);
+      } else if (!once) {
+        set(value);
+        setOnce(true);
+      }
+    }
+  }, [value]);
+  const methods = { set, get, submit, clear, getAll };
+  return [ref, methods];
+}


### PR DESCRIPTION
增加一个form hook
主要实现如下功能

- 简化原有的form调用方式
- 数据的初始化逻辑调整为 当value为空时不设置表单初始值. 便于从服务器拉取的值在initialValues初始化时未设置需要手动设置
- 增加数据双向同步,每次value变化时 自动设置表单