### PR TITLE
docs(field): 修正 field 组件的文档错误

### DIFF
--- a/packages/react-vant/src/field/README.md
+++ b/packages/react-vant/src/field/README.md
@@ -244,7 +244,7 @@ export default () => {
 
 | 事件             | 说明                 | 回调参数                |
 | ---------------- | -------------------- | ----------------------- |
-| onChange         | 输入框获得焦点时触发 | _val: string \| number_ |
+| onChange         | 当值变化时触发      | _val: string \| number_ |
 | onFocus          | 输入框获得焦点时触发 | _event: MouseEvent_     |
 | onBlur           | 输入框失去焦点时触发 | _event: MouseEvent_     |
 | onClear          | 点击清除按钮时触发   | _event: MouseEvent_     |

--- a/packages/react-vant/src/field/README.md
+++ b/packages/react-vant/src/field/README.md
@@ -124,11 +124,23 @@ export default () => {
  * title: 高度自适应
  * card: true
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { Field } from 'react-vant';
 
 export default () => {
-  return <Field rows={1} autosize label="留言" type="textarea" placeholder="请输入留言" />;
+  const [content, setContent] = useState('');
+
+  return (
+    <Field
+      rows={1}
+      autosize
+      value={content}
+      onChange={setContent}
+      label="留言"
+      type="textarea"
+      placeholder="请输入留言"
+    />
+  );
 };
 ```
 

--- a/packages/react-vant/src/field/README.md
+++ b/packages/react-vant/src/field/README.md
@@ -153,10 +153,12 @@ export default () => {
  * title: 显示字数统计
  * card: true
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { Field } from 'react-vant';
 
 export default () => {
+  const [content, setContent] = useState('');
+
   return (
     <Field
       rows={2}
@@ -164,6 +166,8 @@ export default () => {
       label="留言"
       type="textarea"
       placeholder="请输入留言"
+      value={content}
+      onChange={setContent}
       maxlength={50}
       showWordLimit
     />


### PR DESCRIPTION
**修正 autosize 示例无法自适应问题**

[文档示例](https://3lang3.github.io/react-vant/#/zh-CN/field) 中的 autosize 示例无法自动适应内容高度，需要改写为受控组件。

**修正 showWordLimit 示例当前字数一直为 0 问题**

同上，改写为受控组件恢复正常。

**修正 onChnage 的 api 介绍**

onChange 的介绍和 onFocus  介绍重复