### PR TITLE
feat: `Search` 新增 `action` 用于自定义右侧操作内容 #580

### DIFF
--- a/packages/react-vant/src/components/search/PropsType.ts
+++ b/packages/react-vant/src/components/search/PropsType.ts
@@ -11,6 +11,7 @@ export interface SearchProps extends FieldCommonProps {
   /** 是否在搜索框右侧显示取消按钮	 */
   showAction?: Boolean
   /** 搜索框形状，可选值为 round	 */
+  action?: React.ReactNode
   shape?: 'square' | 'round'
   /**  确定搜索时触发	 */
   onSearch?: (val: string) => void

--- a/packages/react-vant/src/components/search/README.md
+++ b/packages/react-vant/src/components/search/README.md
@@ -172,6 +172,7 @@ export default () => {
 | autoFocus | 是否自动聚焦，iOS 系统不支持该属性 | _boolean_ | `false` |
 | showAction | 是否在搜索框右侧显示取消按钮 | _boolean_ | `false` |
 | actionText | 取消按钮文字 | _ReactNode_ | `取消` |
+| action | 自定义右侧操作内容，会覆盖 `showAction` 和 `actionText` 行为 | _ReactNode_ | - |
 | disabled | 是否禁用输入框 | _boolean_ | `false` |
 | readOnly | 是否将输入框设为只读状态，只读状态下无法输入内容 | _boolean_ | `false` |
 | error | 是否将输入内容标红 | _boolean_ | `false` |

--- a/packages/react-vant/src/components/search/Search.tsx
+++ b/packages/react-vant/src/components/search/Search.tsx
@@ -68,6 +68,7 @@ const Search = forwardRef<SearchInstance, SearchProps>((props, ref) => {
   }
 
   const renderAction = () => {
+    if (props.action) return props.action
     if (props.showAction) {
       return (
         <div


### PR DESCRIPTION
- close #580 