### PR TITLE
fix(v2): checker add style

### DIFF
--- a/packages/react-vant/src/components/checkbox/Checker.tsx
+++ b/packages/react-vant/src/components/checkbox/Checker.tsx
@@ -86,6 +86,7 @@ const Checker: React.FC<CheckerProps<{}>> = (props) => {
         ]),
         props.className,
       )}
+      style={props.style}
       tabIndex={disabled ? -1 : 0}
       aria-checked={props.checked}
       onClick={onClick}


### PR DESCRIPTION
Fix #524 
Thanks to #526 , this pr let Checker recognize the forwarded `style` prop