### PR TITLE
fix(Input): ignore value check during composition

### DIFF
--- a/packages/react-vant/src/components/input/Input.tsx
+++ b/packages/react-vant/src/components/input/Input.tsx
@@ -73,18 +73,19 @@ const Input = forwardRef<InputInstance, InputProps>((props, ref) => {
     return false
   }, [value, props.clearTrigger, inputFocus])
 
-  const handleChange = e => {
-    const inputValue = e?.currentTarget?.value
+  const handleValueChange = (inputValue?: string) => {
     let finalValue = inputValue
 
-    if (isDef(maxLength) && finalValue.length > +maxLength) {
-      finalValue = finalValue.slice(0, maxLength)
-      props.onOverlimit?.()
-    }
+    if (!compositionStartRef.current) {
+      if (isDef(maxLength) && finalValue.length > +maxLength) {
+        finalValue = finalValue.slice(0, maxLength)
+        props.onOverlimit?.()
+      }
 
-    if (type === 'number' || type === 'digit') {
-      const isNumber = type === 'number'
-      finalValue = formatNumber(finalValue, isNumber, isNumber)
+      if (type === 'number' || type === 'digit') {
+        const isNumber = type === 'number'
+        finalValue = formatNumber(finalValue, isNumber, isNumber)
+      }
     }
 
     setValue(finalValue)
@@ -147,7 +148,7 @@ const Input = forwardRef<InputInstance, InputProps>((props, ref) => {
         placeholder={placeholder || ''}
         onBlur={handleBulr}
         onFocus={handleFocus}
-        onChange={handleChange}
+        onChange={e => handleValueChange(e?.currentTarget?.value)}
         onKeyPress={handleKeyPress}
         autoCapitalize={props.autoCapitalize}
         autoCorrect={props.autoCorrect}
@@ -160,6 +161,7 @@ const Input = forwardRef<InputInstance, InputProps>((props, ref) => {
         onCompositionEnd={e => {
           compositionStartRef.current = false
           props.onCompositionEnd?.(e)
+          handleValueChange(e?.currentTarget?.value)
         }}
         onClick={props.onClick}
       />

--- a/packages/react-vant/src/components/text-area/TextArea.tsx
+++ b/packages/react-vant/src/components/text-area/TextArea.tsx
@@ -92,12 +92,14 @@ const TextArea = forwardRef<TextAreaInstance, TextAreaProps>((props, ref) => {
     ])
   }, [props.autoSize])
 
-  const handleChange = e => {
-    const inputValue = e?.currentTarget?.value
+  const handleValueChange = (inputValue?: string) => {
     let finalValue = inputValue
 
-    if (isDef(maxLength) && finalValue.length > +maxLength) {
-      finalValue = finalValue.slice(0, maxLength)
+    if (!compositionStartRef.current) {
+      if (isDef(maxLength) && finalValue.length > +maxLength) {
+        finalValue = finalValue.slice(0, maxLength)
+        props.onOverlimit?.()
+      }
     }
 
     setValue(finalValue)
@@ -170,7 +172,7 @@ const TextArea = forwardRef<TextAreaInstance, TextAreaProps>((props, ref) => {
         placeholder={placeholder || ''}
         onBlur={handleBulr}
         onFocus={handleFocus}
-        onChange={handleChange}
+        onChange={e => handleValueChange(e?.currentTarget?.value)}
         onKeyPress={props.onKeyPress}
         onKeyDown={props.onKeyDown}
         onKeyUp={props.onKeyUp}
@@ -182,6 +184,7 @@ const TextArea = forwardRef<TextAreaInstance, TextAreaProps>((props, ref) => {
         onCompositionEnd={e => {
           compositionStartRef.current = false
           props.onCompositionEnd?.(e as any)
+          handleValueChange(e?.currentTarget?.value)
         }}
         onClick={
           props.onClick as unknown as React.HTMLAttributes<HTMLTextAreaElement>['onClick']


### PR DESCRIPTION
fix: #628 

- Input
- TextArea

预输入时不限制长度，并在结束时重新处理