### PR TITLE
fix(FloatingPanel): fix stuck during indetermine direction

### DIFF
--- a/packages/react-vant/src/components/floating-panel/FloatingPanel.tsx
+++ b/packages/react-vant/src/components/floating-panel/FloatingPanel.tsx
@@ -1,6 +1,11 @@
 import React, { forwardRef, useImperativeHandle, useMemo, useRef } from 'react'
 import clsx from 'clsx'
-import { createNamespace, preventDefault } from '../utils'
+import {
+  createNamespace,
+  getScrollTop,
+  getVisibleHeight,
+  preventDefault,
+} from '../utils'
 import useEventListener from '../hooks/use-event-listener'
 import { useTouch } from '../hooks'
 import { FloatingPanelInstance, FloatingPanelProps } from './PropsType'
@@ -53,8 +58,11 @@ const FloatingPanel = forwardRef<FloatingPanelInstance, FloatingPanelProps>(
           // attempt scroll at max anchor
           (touch.deltaY.current < 0 &&
             visibleH.goal >= maxAnchor &&
-            bodyEL.offsetHeight < bodyEL.scrollHeight &&
-            !(bodyEL.scrollTop + bodyEL.offsetHeight >= bodyEL.scrollHeight)) ||
+            getVisibleHeight(bodyEL) < bodyEL.scrollHeight &&
+            !(
+              getScrollTop(bodyEL) + getVisibleHeight(bodyEL) >=
+              bodyEL.scrollHeight
+            )) ||
           // attempt scroll back to top at max anchor
           (touch.deltaY.current > 0 && bodyEL.scrollTop > 0)
         ) {

--- a/packages/react-vant/src/components/floating-panel/FloatingPanel.tsx
+++ b/packages/react-vant/src/components/floating-panel/FloatingPanel.tsx
@@ -51,23 +51,23 @@ const FloatingPanel = forwardRef<FloatingPanelInstance, FloatingPanelProps>(
     const onTouchMove: EventListener = event => {
       if (!body.current || !header.current) return
       touch.move(event)
-      if (!touch.direction.current) return
-      if (touch.firstMove.current && touch.isVertical()) {
+      if (touch.firstMove.current) {
         const bodyEL = body.current
-        if (
-          // attempt scroll at max anchor
-          (touch.deltaY.current < 0 &&
-            visibleH.goal >= maxAnchor &&
-            getVisibleHeight(bodyEL) < bodyEL.scrollHeight &&
-            !(
-              getScrollTop(bodyEL) + getVisibleHeight(bodyEL) >=
-              bodyEL.scrollHeight
-            )) ||
-          // attempt scroll back to top at max anchor
-          (touch.deltaY.current > 0 && bodyEL.scrollTop > 0)
-        ) {
-          dragging.current = false
-          return
+        if (visibleH.goal >= maxAnchor) {
+          if (
+            // attempt scroll at max anchor
+            (touch.deltaY.current < 0 &&
+              getVisibleHeight(bodyEL) < bodyEL.scrollHeight &&
+              !(
+                getScrollTop(bodyEL) + getVisibleHeight(bodyEL) >=
+                bodyEL.scrollHeight
+              )) ||
+            // attempt scroll back to top at max anchor
+            (touch.deltaY.current > 0 && bodyEL.scrollTop > 0)
+          ) {
+            dragging.current = false
+            return
+          }
         }
       }
       if (event.target === header.current) dragging.current = true

--- a/packages/react-vant/src/components/floating-panel/FloatingPanel.tsx
+++ b/packages/react-vant/src/components/floating-panel/FloatingPanel.tsx
@@ -46,6 +46,7 @@ const FloatingPanel = forwardRef<FloatingPanelInstance, FloatingPanelProps>(
     const onTouchMove: EventListener = event => {
       if (!body.current || !header.current) return
       touch.move(event)
+      if (!touch.direction.current) return
       if (touch.firstMove.current && touch.isVertical()) {
         const bodyEL = body.current
         if (

--- a/packages/react-vant/src/components/floating-panel/FloatingPanel.tsx
+++ b/packages/react-vant/src/components/floating-panel/FloatingPanel.tsx
@@ -46,8 +46,7 @@ const FloatingPanel = forwardRef<FloatingPanelInstance, FloatingPanelProps>(
     const onTouchMove: EventListener = event => {
       if (!body.current || !header.current) return
       touch.move(event)
-      if (touch.firstMove.current) {
-        dragging.current = touch.isVertical()
+      if (touch.firstMove.current && touch.isVertical()) {
         const bodyEL = body.current
         if (
           // attempt scroll at max anchor

--- a/packages/react-vant/src/components/floating-panel/FloatingPanel.tsx
+++ b/packages/react-vant/src/components/floating-panel/FloatingPanel.tsx
@@ -46,7 +46,8 @@ const FloatingPanel = forwardRef<FloatingPanelInstance, FloatingPanelProps>(
     const onTouchMove: EventListener = event => {
       if (!body.current || !header.current) return
       touch.move(event)
-      if (touch.firstMove.current && touch.isVertical()) {
+      if (touch.firstMove.current) {
+        dragging.current = touch.isVertical()
         const bodyEL = body.current
         if (
           // attempt scroll at max anchor

--- a/packages/react-vant/src/components/hooks/use-touch.ts
+++ b/packages/react-vant/src/components/hooks/use-touch.ts
@@ -49,7 +49,11 @@ export default function useTouch() {
     deltaY.current = touch.clientY - startY.current
     offsetX.current = Math.abs(deltaX.current)
     offsetY.current = Math.abs(deltaY.current)
-    firstMove.current = !direction.current
+    if (firstMove.current === null) {
+      firstMove.current = true
+    } else {
+      firstMove.current = false
+    }
 
     if (!direction.current) {
       direction.current = getDirection(offsetX.current, offsetY.current)

--- a/packages/react-vant/src/components/hooks/use-touch.ts
+++ b/packages/react-vant/src/components/hooks/use-touch.ts
@@ -22,7 +22,7 @@ export default function useTouch() {
   const offsetX = useRef(0)
   const offsetY = useRef(0)
   const direction = useRef<Direction>('')
-  const firstMove = useRef(false)
+  const firstMove = useRef<boolean>(null)
 
   const isVertical = () => direction.current === 'vertical'
   const isHorizontal = () => direction.current === 'horizontal'
@@ -33,7 +33,7 @@ export default function useTouch() {
     offsetX.current = 0
     offsetY.current = 0
     direction.current = ''
-    firstMove.current = false
+    firstMove.current = null
   }
 
   const start = ((event: TouchEvent) => {


### PR DESCRIPTION
iOS: if touch events triggered but touch direction not recognized by `getDirection`, then 
1. FloatingPanel(FP) treat this touch as dragging and prevent it.
2. Until direction recognized and we try to scroll content, FP think it is not dragging then expectedly ignore
3. But the first touch move event is prevented, subsequent events are not active for content scrolling.


Reproduction: 
https://react-vant-pr-627.surge.sh/~demo/components/floating-panel 
1. Scroll panel to max anchor
2. Try scroll content
3. Get stuck sometimes.