### PR TITLE
chore(deps): update @vant/popperjs to v1.3.0

### DIFF
--- a/packages/react-vant/package.json
+++ b/packages/react-vant/package.json
@@ -84,7 +84,7 @@
     "@react-spring/web": "^9.4.5",
     "@react-vant/icons": "workspace:*",
     "@use-gesture/react": "10.2.17",
-    "@vant/popperjs": "^1.1.0",
+    "@vant/popperjs": "^1.3.0",
     "clsx": "1.2.1",
     "rc-field-form": "^1.26.4",
     "react-is": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
       '@types/react-dom': 18.0.7
       '@use-gesture/react': 10.2.17
       '@vant/area-data': 1.3.1
-      '@vant/popperjs': ^1.1.0
+      '@vant/popperjs': ^1.3.0
       clsx: 1.2.1
       gulp: 4.0.2
       gulp-postcss: 9.0.1
@@ -63,7 +63,7 @@ importers:
       '@react-spring/web': 9.4.5_biqbaboplfbrettd7655fr4n2y
       '@react-vant/icons': link:../react-vant-icons
       '@use-gesture/react': 10.2.17_react@18.2.0
-      '@vant/popperjs': 1.2.0
+      '@vant/popperjs': 1.3.0
       clsx: 1.2.1
       rc-field-form: 1.26.6_biqbaboplfbrettd7655fr4n2y
       react-is: 18.2.0
@@ -3069,10 +3069,6 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@popperjs/core/2.11.5:
-    resolution: {integrity: sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==}
-    dev: false
-
   /@rcdoc/build/0.1.11:
     resolution: {integrity: sha512-M8uhfEaTTT+vYGq53tHm/QvomqXXfxNePPbCBxIzyq7hXUOzs5TwggIulrlY4e7lTPDkLlcOwdbtPnWDJlV+sQ==}
     hasBin: true
@@ -3691,10 +3687,8 @@ packages:
     resolution: {integrity: sha512-xji2kfVBXzFYmHAJNbhYjiRJ4GnN+enbTmtx6FnpTyxs9sUcFtS11BZ23hYCGuj4s02gXyrzUBTXGqhX5IKHIw==}
     dev: true
 
-  /@vant/popperjs/1.2.0:
-    resolution: {integrity: sha512-YdtVBcNCsZqCBu7vUvpTm9MG4V+Hz5UmCr7UZlNXoYXZbDD238ncqNStw+gQVWySeCY5yAQVOT6deJN5poVe8g==}
-    dependencies:
-      '@popperjs/core': 2.11.5
+  /@vant/popperjs/1.3.0:
+    resolution: {integrity: sha512-hB+czUG+aHtjhaEmCJDuXOep0YTZjdlRR+4MSmIFnkCQIxJaXLQdSsR90XWvAI2yvKUI7TCGqR8pQg2RtvkMHw==}
     dev: false
 
   /@vant/touch-emulator/1.3.2:
@@ -6566,7 +6560,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
     requiresBuild: true
     dependencies:
       bindings: 1.5.0


### PR DESCRIPTION
`@vant/popperjs` v1.2.0 开始增加 package.json `export` 字段以提供包括 nuxt3、vite 在内的大部分打包工具 resolve 模块的指引

`@vant/popperjs` v1.3.0 相比 v1.2.0 多导出一个 type，看起来对现有仓库无影响

> popperjs 用于 Popover 组件
