### PR TITLE
fix(tabs): 修复 tabs 组件选中下划线在初始化时会从最左面移到目标位置的问题

### DIFF
--- a/packages/react-vant/src/components/tabs/Tabs.tsx
+++ b/packages/react-vant/src/components/tabs/Tabs.tsx
@@ -107,12 +107,14 @@ const Tabs = forwardRef<TabsInstance, TabsProps>((props, ref) => {
 
   // 下划线偏移量
   const [lineTranslateLeft, setLineTranslateLeft] = useState<number>(0)
+  const [showLine, setShowLine] = useState<boolean>(false)
   useUpdateEffect(() => {
     const hidden = isHidden(root.current)
     const title = titleRefs?.[index]
     if (!title || hidden || props.type !== 'line') {
       return
     }
+    setShowLine(true)
     setLineTranslateLeft(title.offsetLeft + title.offsetWidth / 2)
   }, [root.current, titleRefs, props.type, index])
 
@@ -123,6 +125,7 @@ const Tabs = forwardRef<TabsInstance, TabsProps>((props, ref) => {
       width: addUnit(lineWidth),
       backgroundColor: color,
       transitionDuration: `${immediateRef.current ? 0 : props.duration}ms`,
+      display: showLine ? 'inherit' : 'none',
     } as React.CSSProperties
 
     if (lineTranslateLeft) {
@@ -141,6 +144,7 @@ const Tabs = forwardRef<TabsInstance, TabsProps>((props, ref) => {
     props.lineWidth,
     lineTranslateLeft,
     immediateRef.current,
+    showLine,
   ])
 
   const getAvailableTab = (targetIndex: number) => {


### PR DESCRIPTION
在 vant 以及 antd 等组件中，初始化 tab 组件后，选中下划线会直接定位到选中的 tab 下面：
![vant](https://github.com/3lang3/react-vant/assets/29225966/d228b7d4-b64e-400c-879a-23aa7e49b0b2)

而在 react-vant 中，选中下划线会从最左面移到选中 tab 下面，与 vant 交互不一致，看起来像是过早展现并加载了下划线的动画。
![react-vant](https://github.com/3lang3/react-vant/assets/29225966/3c43ad7e-0612-4a49-9672-77c1015b3280)

该 PR 修复了这个问题，让 react-vant 的 tab 选中下划线的交互和 vant 等主流移动端组件库一致。

cc @3lang3 
