### PR TITLE
fix(datetime-picker): datetime-picker 没有值时，弹出层默认选中当前日期/时间。

### DIFF
--- a/packages/react-vant/src/components/datetime-picker/DatePicker.tsx
+++ b/packages/react-vant/src/components/datetime-picker/DatePicker.tsx
@@ -37,7 +37,7 @@ const DatePicker = forwardRef<DateTimePickerInstance, DatePickerProps>(
 
     const formatValue = date => {
       if (!isDate(date)) {
-        date = minDate
+        date = new Date()
       }
 
       date = Math.max(date, minDate.getTime())


### PR DESCRIPTION
之前是默认显示的最小时间：
<img width="299" alt="image" src="https://github.com/3lang3/react-vant/assets/2948405/2d683458-97e2-47af-97cd-086af74dc768">

大多数情况应该是显示当前时间更方便。

修改后：
<img width="301" alt="image" src="https://github.com/3lang3/react-vant/assets/2948405/e7bb3811-febd-42fc-bbd3-83c723d37828">
