### PR TITLE
fix(demo): 表单组件正则表达式验证示例与实际说明不符

### DIFF
--- a/packages/react-vant/src/components/form/demo/rules.tsx
+++ b/packages/react-vant/src/components/form/demo/rules.tsx
@@ -20,7 +20,7 @@ export default () => {
       <Form.Item
         name='text1'
         label='正则校验'
-        rules={[{ pattern: /\d{6}/, message: '请输入6位数字' }]}
+        rules={[{ pattern: /^\d{6}$/, message: '请输入6位数字' }]}
       >
         <Input placeholder='正则校验' />
       </Form.Item>
@@ -30,7 +30,7 @@ export default () => {
         rules={[
           {
             validator: (_, value) => {
-              if (/1\d{10}/.test(value)) {
+              if (/^1\d{10}$/.test(value)) {
                 return Promise.resolve(true)
               }
               return Promise.reject(new Error('请输入正确的手机号码'))
@@ -50,7 +50,7 @@ export default () => {
                 Toast.loading('验证中...')
 
                 setTimeout(() => {
-                  if (/\d{6}/.test(value)) {
+                  if (/^\d{6}$/.test(value)) {
                     resolve(true)
                   } else {
                     reject(new Error('请输入正确内容'))


### PR DESCRIPTION
文档中原示例代码的正则表达式作用是匹配前几位数字，一但数字超过后，将不再限制，可能产生歧义。（刚开始我还以为验证通过后不再触发验证：D）

![Snipaste_2023-11-22_17-11-54](https://github.com/3lang3/react-vant/assets/15024868/431a3e0d-393f-432b-baf2-2fe426da7374)
