### PR TITLE
feat:新增import locale 类型提示

### DIFF
--- a/packages/react-vant/package.json
+++ b/packages/react-vant/package.json
@@ -52,7 +52,8 @@
     "./2x": "./2x/es/index.js",
     "./2x/": "./2x/",
     "./package.json": "./package.json",
-    "./*": "./*"
+    "./*": "./*",
+    "./es/locale":"./es/locale/index.js"
   },
   "main": "./lib/index.js",
   "jsdelivr": "./bundle/react-vant.min.js",


### PR DESCRIPTION
#670  新增对locale的类型提示  但是仍不支持文档中国际化的import enUS from 'react-vant/es/locale/lang/en-US';
期望能把export 这个字段删除 但是会造成break change 也可以把文档修改下 其实import  {enUs} from 'react-vant' 即可 
<img width="806" alt="image" src="https://github.com/3lang3/react-vant/assets/95938844/4fab2eab-4d42-46b6-b71c-2f322c1c79e5">

 