### PR TITLE
fix(datetime-picker): 默认最小日期最大日期使用常量；

### DIFF
--- a/packages/react-vant/src/components/datetime-picker/DatePicker.tsx
+++ b/packages/react-vant/src/components/datetime-picker/DatePicker.tsx
@@ -19,8 +19,8 @@ const DatePicker = forwardRef<DateTimePickerInstance, DatePickerProps>(
     const props = mergeProps(p, {
       type: 'datetime',
       placeholder: false,
-      minDate: new Date(currentYear - 10, 0, 1),
-      maxDate: new Date(currentYear + 10, 11, 31),
+      minDate: DefaultMinDate,
+      maxDate: DefaultMaxDate,
       formatter: (type: string, value: string) => value,
     })
     const {
@@ -280,5 +280,7 @@ const DatePicker = forwardRef<DateTimePickerInstance, DatePickerProps>(
 )
 
 const currentYear = new Date().getFullYear()
+const DefaultMinDate = new Date(currentYear - 10, 0, 1)
+const DefaultMaxDate = new Date(currentYear + 10, 11, 31)
 
 export default DatePicker


### PR DESCRIPTION
将默认的最小日期最大日期改用常量，修复当未设置最小日期/最大日期时，在每个渲染周期都使用新的Date对象，导致下段代码异常重复执行，而引起 confirm 时 value 不正确（fix #663 ）：

```
    useUpdateEffect(() => {
      const nextValue = formatValue(value)

      if (nextValue && nextValue.valueOf() !== currentDate?.valueOf()) {
        setCurrentDate(nextValue)
      }
    }, [value, filter, minDate, maxDate])

```