### PR TITLE
fix(form): 表单组件属性layout为vertical，由nextjs打包后样式被层叠无效

### DIFF
--- a/packages/react-vant/src/components/form/style/index.less
+++ b/packages/react-vant/src/components/form/style/index.less
@@ -6,7 +6,7 @@
       flex-wrap: wrap;
       .@{rv-prefix}-field__label {
         margin-bottom: 8 * @hd;
-        width: 100%;
+        width: 100% !important;
         flex: none;
       }
     }


### PR DESCRIPTION
react vant 3.3.3 版本，NextJS(13和14) 项目打包后，`.rv-form-item--vertical .rv-field__label` 优先级会被 `.rv-field .rv-field__label `层叠，导致无法起作用。

可能有更好的解决办法

> 顺便提一提：`CONTRIBUTING.md` 中 `npm run bootstrap` 脚本找不到，且可能由于`NodeJS`版本不统一，导致项目无法启动开发环境

开发阶段：
![dev](https://github.com/3lang3/react-vant/assets/15024868/1d131573-e517-4360-bb29-9ebcc75a1317)

打包后：
![build](https://github.com/3lang3/react-vant/assets/15024868/f1a56d0e-2f3f-46c7-ad91-d1b229676591)

