### PR TITLE
修复 Picker 在 ios 下通过 from.setFieldValue 设置 value 后第一次弹出没有选中对应 value 的问题

### DIFF
--- a/packages/react-vant/src/components/picker/Picker.tsx
+++ b/packages/react-vant/src/components/picker/Picker.tsx
@@ -80,7 +80,7 @@ function PickerInner<T = PickerColumnOption>(props: PickerMultipleProps<T>) {
     },
     [innerValue],
     {
-      wait: 0,
+      wait: 50,
       leading: false,
       trailing: true,
     }

--- a/packages/react-vant/src/components/toast/method.tsx
+++ b/packages/react-vant/src/components/toast/method.tsx
@@ -68,10 +68,14 @@ const ToastObj = (p: ToastProps): unknown => {
       if (state.forbidClick) {
         lockClick(false)
       }
-      const unmountResult = unmount(container)
-      if (unmountResult && container.parentNode) {
-        container.parentNode.removeChild(container)
-      }
+      setVisible(false)
+      window.setTimeout(() => {
+        const unmountResult = unmount(container)
+        if (unmountResult && container.parentNode) {
+          container.parentNode.removeChild(container)
+        }
+      }, +state.duration || +defaultOptions.duration)
+
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [container])
 


### PR DESCRIPTION
修复 Picker 在 ios 下通过 from.setFieldValue 设置 value 后第一次弹出没有选中对应 value 的问题