### PR TITLE
fix: build icon type error

### DIFF
--- a/packages/react-vant-icons/package.json
+++ b/packages/react-vant-icons/package.json
@@ -28,7 +28,7 @@
     "@babel/core": "7.23.3",
     "@babel/plugin-transform-modules-commonjs": "7.23.3",
     "@svgr/babel-plugin-remove-jsx-attribute": "6.5.0",
-    "@types/react": "18.0.17",
+    "@types/react": "18.3.2",
     "del": "6.1.1",
     "fast-glob": "3.2.12",
     "fs-extra": "10.1.0",


### PR DESCRIPTION
Fixed the ts type error in react caused by @type/react in the new version
<img width="973" alt="image" src="https://github.com/3lang3/react-vant/assets/22758379/994250b4-1cbf-4ab4-8093-010d67e18cec">
