### PR TITLE
fix(Component):  leftIcon className been overwritten in cell component

### DIFF
--- a/packages/react-vant/src/components/cell/Cell.tsx
+++ b/packages/react-vant/src/components/cell/Cell.tsx
@@ -54,7 +54,7 @@ const Cell: React.FC<CellProps> = props => {
   const renderLeftIcon = () => {
     if (props.icon) {
       return React.cloneElement(props.icon as React.ReactElement, {
-        className: clsx(bem('left-icon')),
+        className: clsx(props.icon?.props?.className ?? '', bem('left-icon')),
       })
     }
     return null


### PR DESCRIPTION
#724 Fixed leftIcon className been overwritten in cell component When Icon componet set className attr