### PR TITLE
fix(input): 修复 复制包含多个'-'的数字到input type=digit 时，格式错误

### DIFF
--- a/packages/react-vant/src/components/utils/format/number.ts
+++ b/packages/react-vant/src/components/utils/format/number.ts
@@ -32,7 +32,7 @@ export function formatNumber(
   if (allowMinus) {
     value = trimExtraChar(value, '-', /-/g)
   } else {
-    value = value.replace(/-/, '')
+    value = value.replace(/-/g, '')
   }
 
   const regExp = allowDot ? /[^-0-9.]/g : /[^-0-9]/g


### PR DESCRIPTION
复制 如 1-1-1的数字，到input type="digit"，处理格式有误。期望是 1-1-1  -> 111，但实际时 1-1-1 -> 11-1